### PR TITLE
各DockerイメージにJDBCドライバーを1種類しか入れない

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -35,18 +35,7 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1.6.0
       -
-        name: Build and Push (base)
-        uses: docker/build-push-action@v2
+        name: Docker Buildx Bake
+        uses: docker/bake-action@v1.7.0
         with:
-          platforms: linux/amd64,linux/arm64
           push: true
-          target: main
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/schemaspy:6.1.0
-      -
-        name: Build and Push (cjk)
-        uses: docker/build-push-action@v2
-        with:
-          platforms: linux/amd64,linux/arm64
-          push: true
-          target: cjk
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/schemaspy:6.1.0-cjk

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -9,7 +9,7 @@ on:
 #  push
 
 env:
-  PREFIX: "${{ secrets.DOCKERHUB_USERNAME }}/schemaspy"
+  PREFIX: ${{ secrets.DOCKERHUB_USERNAME }}
 
 jobs:
   docker:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,6 +8,9 @@ on:
 #on:
 #  push
 
+env:
+  PREFIX: ${{ secrets.DOCKERHUB_USERNAME }}
+
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -9,7 +9,7 @@ on:
 #  push
 
 env:
-  PREFIX: ${{ secrets.DOCKERHUB_USERNAME }}
+  PREFIX: "${{ secrets.DOCKERHUB_USERNAME }}/schemaspy"
 
 jobs:
   docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,54 @@ ARG SCHEMASPY_VERSION=6.1.0
 ARG MYSQL_VERSION=6.0.6
 ARG MARIADB_VERSION=1.1.10
 ARG POSTGRESQL_VERSION=42.1.1
-ARG JTDS_VERSION=1.3.1
 
-FROM curlimages/curl:latest AS download
+# Download files
+FROM curlimages/curl:latest AS download-mysql
+
+ENV LC_ALL=C
+
+ARG GIT_BRANCH
+ARG GIT_REVISION
+
+ARG MYSQL_VERSION
+
+ENV MYSQL_VERSION=$MYSQL_VERSION
+
+RUN mkdir -p /tmp/drivers_inc
+WORKDIR /tmp/drivers_inc
+RUN curl -JLO http://search.maven.org/remotecontent?filepath=mysql/mysql-connector-java/$MYSQL_VERSION/mysql-connector-java-$MYSQL_VERSION.jar
+
+FROM curlimages/curl:latest AS download-mariadb
+
+ENV LC_ALL=C
+
+ARG GIT_BRANCH
+ARG GIT_REVISION
+
+ARG MARIADB_VERSION
+
+ENV MARIADB_VERSION=$MARIADB_VERSION
+
+RUN mkdir -p /tmp/drivers_inc
+WORKDIR /tmp/drivers_inc
+RUN curl -JLO http://search.maven.org/remotecontent?filepath=org/mariadb/jdbc/mariadb-java-client/$MARIADB_VERSION/mariadb-java-client-$MARIADB_VERSION.jar
+
+FROM curlimages/curl:latest AS download-postgresql
+
+ENV LC_ALL=C
+
+ARG GIT_BRANCH
+ARG GIT_REVISION
+
+ARG POSTGRESQL_VERSION
+
+ENV POSTGRESQL_VERSION=$POSTGRESQL_VERSION
+
+RUN mkdir -p /tmp/drivers_inc
+WORKDIR /tmp/drivers_inc
+RUN curl -JLO http://search.maven.org/remotecontent?filepath=org/postgresql/postgresql/$POSTGRESQL_VERSION.jre7/postgresql-$POSTGRESQL_VERSION.jre7.jar
+
+FROM curlimages/curl:latest AS download-schemaspy
 
 ENV LC_ALL=C
 
@@ -15,55 +60,32 @@ ARG GIT_BRANCH
 ARG GIT_REVISION
 
 ARG SCHEMASPY_VERSION
-ARG MYSQL_VERSION
-ARG MARIADB_VERSION
-ARG POSTGRESQL_VERSION
-ARG JTDS_VERSION
 
 ENV SCHEMASPY_VERSION=$SCHEMASPY_VERSION
-ENV MYSQL_VERSION=$MYSQL_VERSION
-ENV MARIADB_VERSION=$MARIADB_VERSION
-ENV POSTGRESQL_VERSION=$POSTGRESQL_VERSION
-ENV JTDS_VERSION=$JTDS_VERSION
-
-RUN mkdir -p /tmp/drivers_inc
-WORKDIR /tmp/drivers_inc
-RUN curl -JLO http://search.maven.org/remotecontent?filepath=mysql/mysql-connector-java/$MYSQL_VERSION/mysql-connector-java-$MYSQL_VERSION.jar
-RUN curl -JLO http://search.maven.org/remotecontent?filepath=org/mariadb/jdbc/mariadb-java-client/$MARIADB_VERSION/mariadb-java-client-$MARIADB_VERSION.jar
-RUN curl -JLO http://search.maven.org/remotecontent?filepath=org/postgresql/postgresql/$POSTGRESQL_VERSION.jre7/postgresql-$POSTGRESQL_VERSION.jre7.jar
-RUN curl -JLO http://search.maven.org/remotecontent?filepath=net/sourceforge/jtds/jtds/$JTDS_VERSION/jtds-$JTDS_VERSION.jar
 
 RUN mkdir -p /tmp/download
 WORKDIR /tmp/download
 RUN curl -JLO https://github.com/schemaspy/schemaspy/releases/download/v${SCHEMASPY_VERSION}/schemaspy-${SCHEMASPY_VERSION}.jar
 
-FROM openjdk:8u322-jre-slim-bullseye AS main
+# Build images
+FROM openjdk:8u322-jre-slim-bullseye AS mysql
 
 ARG GIT_BRANCH
 ARG GIT_REVISION
 
 ARG SCHEMASPY_VERSION
 ARG MYSQL_VERSION
-ARG MARIADB_VERSION
-ARG POSTGRESQL_VERSION
-ARG JTDS_VERSION
 
 ENV SCHEMASPY_VERSION=$SCHEMASPY_VERSION
 ENV MYSQL_VERSION=$MYSQL_VERSION
-ENV MARIADB_VERSION=$MARIADB_VERSION
-ENV POSTGRESQL_VERSION=$POSTGRESQL_VERSION
-ENV JTDS_VERSION=$JTDS_VERSION
 
 LABEL MYSQL_VERSION=$MYSQL_VERSION
-LABEL MARIADB_VERSION=$MARIADB_VERSION
-LABEL POSTGRESQL_VERSION=$POSTGRESQL_VERSION
-LABEL JTDS_VERSION=$JTDS_VERSION
 
 LABEL GIT_BRANCH=$GIT_BRANCH
 LABEL GIT_REVISION=$GIT_REVISION
 
-COPY --from=download /tmp/download/schema*.jar /usr/local/lib/schemaspy/
-COPY --from=download /tmp/drivers_inc /drivers_inc
+COPY --from=download-schemaspy /tmp/download/schema*.jar /usr/local/lib/schemaspy/
+COPY --from=download-mysql /tmp/drivers_inc /drivers_inc
 COPY docker/schemaspy.sh /usr/local/bin/schemaspy
 
 RUN useradd java && \
@@ -82,33 +104,168 @@ ENV SCHEMASPY_OUTPUT=/output
 
 ENTRYPOINT ["/usr/local/bin/schemaspy"]
 
-FROM openjdk:8u322-jre-slim-bullseye AS cjk
+FROM openjdk:8u322-jre-slim-bullseye AS mariadb
+
+ARG GIT_BRANCH
+ARG GIT_REVISION
+
+ARG SCHEMASPY_VERSION
+ARG MARIADB_VERSION
+
+ENV SCHEMASPY_VERSION=$SCHEMASPY_VERSION
+ENV MARIADB_VERSION=$MARIADB_VERSION
+
+LABEL MARIADB_VERSION=$MARIADB_VERSION
+
+LABEL GIT_BRANCH=$GIT_BRANCH
+LABEL GIT_REVISION=$GIT_REVISION
+
+COPY --from=download-schemaspy /tmp/download/schema*.jar /usr/local/lib/schemaspy/
+COPY --from=download-mariadb /tmp/drivers_inc /drivers_inc
+COPY docker/schemaspy.sh /usr/local/bin/schemaspy
+
+RUN useradd java && \
+    apt-get update && \
+    apt-get -y install --no-install-recommends unzip graphviz && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir /output && \
+    chown -R java /output
+
+USER java
+WORKDIR /
+
+ENV SCHEMASPY_DRIVERS=/drivers
+ENV SCHEMASPY_OUTPUT=/output
+
+ENTRYPOINT ["/usr/local/bin/schemaspy"]
+
+FROM openjdk:8u322-jre-slim-bullseye AS postgresql
+
+ARG GIT_BRANCH
+ARG GIT_REVISION
+
+ARG SCHEMASPY_VERSION
+ARG POSTGRESQL_VERSION
+
+ENV SCHEMASPY_VERSION=$SCHEMASPY_VERSION
+ENV POSTGRESQL_VERSION=$POSTGRESQL_VERSION
+
+LABEL POSTGRESQL_VERSION=$POSTGRESQL_VERSION
+
+LABEL GIT_BRANCH=$GIT_BRANCH
+LABEL GIT_REVISION=$GIT_REVISION
+
+COPY --from=download-schemaspy /tmp/download/schema*.jar /usr/local/lib/schemaspy/
+COPY --from=download-postgresql /tmp/drivers_inc /drivers_inc
+COPY docker/schemaspy.sh /usr/local/bin/schemaspy
+
+RUN useradd java && \
+    apt-get update && \
+    apt-get -y install --no-install-recommends unzip graphviz && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir /output && \
+    chown -R java /output
+
+USER java
+WORKDIR /
+
+ENV SCHEMASPY_DRIVERS=/drivers
+ENV SCHEMASPY_OUTPUT=/output
+
+ENTRYPOINT ["/usr/local/bin/schemaspy"]
+
+FROM openjdk:8u322-jre-slim-bullseye AS mysql-cjk
 
 ARG GIT_BRANCH
 ARG GIT_REVISION
 
 ARG SCHEMASPY_VERSION
 ARG MYSQL_VERSION
-ARG MARIADB_VERSION
-ARG POSTGRESQL_VERSION
-ARG JTDS_VERSION
 
 ENV SCHEMASPY_VERSION=$SCHEMASPY_VERSION
 ENV MYSQL_VERSION=$MYSQL_VERSION
-ENV MARIADB_VERSION=$MARIADB_VERSION
-ENV POSTGRESQL_VERSION=$POSTGRESQL_VERSION
-ENV JTDS_VERSION=$JTDS_VERSION
 
 LABEL MYSQL_VERSION=$MYSQL_VERSION
-LABEL MARIADB_VERSION=$MARIADB_VERSION
-LABEL POSTGRESQL_VERSION=$POSTGRESQL_VERSION
-LABEL JTDS_VERSION=$JTDS_VERSION
 
 LABEL GIT_BRANCH=$GIT_BRANCH
 LABEL GIT_REVISION=$GIT_REVISION
 
-COPY --from=download /tmp/download/schema*.jar /usr/local/lib/schemaspy/
-COPY --from=download /tmp/drivers_inc /drivers_inc
+COPY --from=download-schemaspy /tmp/download/schema*.jar /usr/local/lib/schemaspy/
+COPY --from=download-mysql /tmp/drivers_inc /drivers_inc
+COPY docker/schemaspy.sh /usr/local/bin/schemaspy
+
+RUN useradd java && \
+    apt-get update && \
+    apt-get -y install --no-install-recommends unzip graphviz fonts-noto-cjk && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir /output && \
+    chown -R java /output
+
+USER java
+WORKDIR /
+
+ENV SCHEMASPY_DRIVERS=/drivers
+ENV SCHEMASPY_OUTPUT=/output
+
+ENTRYPOINT ["/usr/local/bin/schemaspy"]
+
+FROM openjdk:8u322-jre-slim-bullseye AS mariadb-cjk
+
+ARG GIT_BRANCH
+ARG GIT_REVISION
+
+ARG SCHEMASPY_VERSION
+ARG MARIADB_VERSION
+
+ENV SCHEMASPY_VERSION=$SCHEMASPY_VERSION
+ENV MARIADB_VERSION=$MARIADB_VERSION
+
+LABEL MARIADB_VERSION=$MARIADB_VERSION
+
+LABEL GIT_BRANCH=$GIT_BRANCH
+LABEL GIT_REVISION=$GIT_REVISION
+
+COPY --from=download-schemaspy /tmp/download/schema*.jar /usr/local/lib/schemaspy/
+COPY --from=download-mariadb /tmp/drivers_inc /drivers_inc
+COPY docker/schemaspy.sh /usr/local/bin/schemaspy
+
+RUN useradd java && \
+    apt-get update && \
+    apt-get -y install --no-install-recommends unzip graphviz fonts-noto-cjk && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir /output && \
+    chown -R java /output
+
+USER java
+WORKDIR /
+
+ENV SCHEMASPY_DRIVERS=/drivers
+ENV SCHEMASPY_OUTPUT=/output
+
+ENTRYPOINT ["/usr/local/bin/schemaspy"]
+
+FROM openjdk:8u322-jre-slim-bullseye AS postgresql-cjk
+
+ARG GIT_BRANCH
+ARG GIT_REVISION
+
+ARG SCHEMASPY_VERSION
+ARG POSTGRESQL_VERSION
+
+ENV SCHEMASPY_VERSION=$SCHEMASPY_VERSION
+ENV POSTGRESQL_VERSION=$POSTGRESQL_VERSION
+
+LABEL POSTGRESQL_VERSION=$POSTGRESQL_VERSION
+
+LABEL GIT_BRANCH=$GIT_BRANCH
+LABEL GIT_REVISION=$GIT_REVISION
+
+COPY --from=download-schemaspy /tmp/download/schema*.jar /usr/local/lib/schemaspy/
+COPY --from=download-postgresql /tmp/drivers_inc /drivers_inc
 COPY docker/schemaspy.sh /usr/local/bin/schemaspy
 
 RUN useradd java && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ ARG GIT_BRANCH=local
 ARG GIT_REVISION=local
 
 ARG SCHEMASPY_VERSION=6.1.0
-ARG MYSQL_VERSION=6.0.6
-ARG MARIADB_VERSION=1.1.10
-ARG POSTGRESQL_VERSION=42.1.1
+ARG MYSQL_VERSION=8.0.28
+ARG MARIADB_VERSION=3.0.3
+ARG POSTGRESQL_VERSION=42.3.3
 
 # Download files
 FROM curlimages/curl:latest AS download-mysql
@@ -20,7 +20,7 @@ ENV MYSQL_VERSION=$MYSQL_VERSION
 
 RUN mkdir -p /tmp/drivers_inc
 WORKDIR /tmp/drivers_inc
-RUN curl -JLO http://search.maven.org/remotecontent?filepath=mysql/mysql-connector-java/$MYSQL_VERSION/mysql-connector-java-$MYSQL_VERSION.jar
+RUN curl -JLO https://search.maven.org/remotecontent?filepath=mysql/mysql-connector-java/$MYSQL_VERSION/mysql-connector-java-$MYSQL_VERSION.jar
 
 FROM curlimages/curl:latest AS download-mariadb
 
@@ -35,7 +35,7 @@ ENV MARIADB_VERSION=$MARIADB_VERSION
 
 RUN mkdir -p /tmp/drivers_inc
 WORKDIR /tmp/drivers_inc
-RUN curl -JLO http://search.maven.org/remotecontent?filepath=org/mariadb/jdbc/mariadb-java-client/$MARIADB_VERSION/mariadb-java-client-$MARIADB_VERSION.jar
+RUN curl -JLO https://search.maven.org/remotecontent?filepath=org/mariadb/jdbc/mariadb-java-client/$MARIADB_VERSION/mariadb-java-client-$MARIADB_VERSION.jar
 
 FROM curlimages/curl:latest AS download-postgresql
 
@@ -50,7 +50,7 @@ ENV POSTGRESQL_VERSION=$POSTGRESQL_VERSION
 
 RUN mkdir -p /tmp/drivers_inc
 WORKDIR /tmp/drivers_inc
-RUN curl -JLO http://search.maven.org/remotecontent?filepath=org/postgresql/postgresql/$POSTGRESQL_VERSION.jre7/postgresql-$POSTGRESQL_VERSION.jre7.jar
+RUN curl -JLO https://search.maven.org/remotecontent?filepath=org/postgresql/postgresql/$POSTGRESQL_VERSION/postgresql-$POSTGRESQL_VERSION.jar
 
 FROM curlimages/curl:latest AS download-schemaspy
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -9,37 +9,37 @@ target "base" {
 target "mysql-nofont" {
     inherits = ["base"]
     target = "mysql"
-    tags = ["${PREFIX}/schemaspy-6.1.0-mysql"]
+    tags = ["${PREFIX}/schemaspy:6.1.0-mysql"]
 }
 
 target "mariadb-nofont" {
     inherits = ["base"]
     target = "mariadb"
-    tags = ["${PREFIX}/schemaspy-6.1.0-mariadb"]
+    tags = ["${PREFIX}/schemaspy:6.1.0-mariadb"]
 }
 
 target "postgresql-nofont" {
     inherits = ["base"]
     target = "postgresql"
-    tags = ["${PREFIX}/schemaspy-6.1.0-postgresql"]
+    tags = ["${PREFIX}/schemaspy:6.1.0-postgresql"]
 }
 
 target "mysql-cjk" {
     inherits = ["base"]
     target = "mysql-cjk"
-    tags = ["${PREFIX}/schemaspy-6.1.0-mysql-cjk"]
+    tags = ["${PREFIX}/schemaspy:6.1.0-mysql-cjk"]
 }
 
 target "mariadb-cjk" {
     inherits = ["base"]
     target = "mariadb-cjk"
-    tags = ["${PREFIX}/schemaspy-6.1.0-mariadb-cjk"]
+    tags = ["${PREFIX}/schemaspy:6.1.0-mariadb-cjk"]
 }
 
 target "postgresql-cjk" {
     inherits = ["base"]
     target = "postgresql-cjk"
-    tags = ["${PREFIX}/schemaspy-6.1.0-postgresql-cjk"]
+    tags = ["${PREFIX}/schemaspy:6.1.0-postgresql-cjk"]
 }
 
 group "mysql" {

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,25 +1,41 @@
+target "base" {
+    platforms = ["linux/amd64", "linux/arm64"]
+}
+
 target "mysql-nofont" {
+    inherits = ["base"]
     target = "mysql"
+    tags = ["schemaspy-6.1.0-mysql"]
 }
 
 target "mariadb-nofont" {
+    inherits = ["base"]
     target = "mariadb"
+    tags = ["schemaspy-6.1.0-mariadb"]
 }
 
 target "postgresql-nofont" {
+    inherits = ["base"]
     target = "postgresql"
+    tags = ["schemaspy-6.1.0-postgresql"]
 }
 
 target "mysql-cjk" {
+    inherits = ["base"]
     target = "mysql-cjk"
+    tags = ["schemaspy-6.1.0-mysql-cjk"]
 }
 
 target "mariadb-cjk" {
+    inherits = ["base"]
     target = "mariadb-cjk"
+    tags = ["schemaspy-6.1.0-mariadb-cjk"]
 }
 
 target "postgresql-cjk" {
+    inherits = ["base"]
     target = "postgresql-cjk"
+    tags = ["schemaspy-6.1.0-postgresql-cjk"]
 }
 
 group "mysql" {

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,3 +1,7 @@
+variable "PREFIX" {
+    default = "docker.io"
+}
+
 target "base" {
     platforms = ["linux/amd64", "linux/arm64"]
 }
@@ -5,37 +9,37 @@ target "base" {
 target "mysql-nofont" {
     inherits = ["base"]
     target = "mysql"
-    tags = ["schemaspy-6.1.0-mysql"]
+    tags = ["${PREFIX}/schemaspy-6.1.0-mysql"]
 }
 
 target "mariadb-nofont" {
     inherits = ["base"]
     target = "mariadb"
-    tags = ["schemaspy-6.1.0-mariadb"]
+    tags = ["${PREFIX}/schemaspy-6.1.0-mariadb"]
 }
 
 target "postgresql-nofont" {
     inherits = ["base"]
     target = "postgresql"
-    tags = ["schemaspy-6.1.0-postgresql"]
+    tags = ["${PREFIX}/schemaspy-6.1.0-postgresql"]
 }
 
 target "mysql-cjk" {
     inherits = ["base"]
     target = "mysql-cjk"
-    tags = ["schemaspy-6.1.0-mysql-cjk"]
+    tags = ["${PREFIX}/schemaspy-6.1.0-mysql-cjk"]
 }
 
 target "mariadb-cjk" {
     inherits = ["base"]
     target = "mariadb-cjk"
-    tags = ["schemaspy-6.1.0-mariadb-cjk"]
+    tags = ["${PREFIX}/schemaspy-6.1.0-mariadb-cjk"]
 }
 
 target "postgresql-cjk" {
     inherits = ["base"]
     target = "postgresql-cjk"
-    tags = ["schemaspy-6.1.0-postgresql-cjk"]
+    tags = ["${PREFIX}/schemaspy-6.1.0-postgresql-cjk"]
 }
 
 group "mysql" {

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,39 @@
+target "mysql-nofont" {
+    target = "mysql"
+}
+
+target "mariadb-nofont" {
+    target = "mariadb"
+}
+
+target "postgresql-nofont" {
+    target = "postgresql"
+}
+
+target "mysql-cjk" {
+    target = "mysql-cjk"
+}
+
+target "mariadb-cjk" {
+    target = "mariadb-cjk"
+}
+
+target "postgresql-cjk" {
+    target = "postgresql-cjk"
+}
+
+group "mysql" {
+    targets = ["mysql-nofont", "mysql-cjk"]
+}
+
+group "mariadb" {
+    targets = ["mariadb-nofont", "mariadb-cjk"]
+}
+
+group "postgresql" {
+    targets = ["postgresql-nofont", "postgresql-cjk"]
+}
+
+group "default" {
+    targets = ["mysql", "mariadb", "postgresql"]
+}


### PR DESCRIPTION
Dockerイメージ縮小のため、同梱するJDBCドライバーを各1種類にする